### PR TITLE
LoRA追加適用を可能に

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ data/chat_logs.db
 # セーブデータ（学習データのバックアップ）
 saves/
 
+# 学習済みLoRAモデルのみ除外
+training/lora_model/
+
 # Python環境関連
 __pycache__/
 *.pyc

--- a/config.py
+++ b/config.py
@@ -2,3 +2,4 @@
 MODEL_PATH = "models/RakutenAI-2.0-mini-instruct" # モデルディレクトリ
 DB_PATH = "data/chat_logs.db"                     # SQLiteデータベースのパス
 SAVE_PATH = "saves/learning_data.json"            # 学習データのエクスポート先
+LORA_PATH = "training/lora_model"


### PR DESCRIPTION
**概要**

- LoRA で学習済みのモデルを chat.py で利用できるように修正
- train.py はまだアップせず、LoRA 適用モデルの使用のみ対応
- MODEL_PATH に LoRA を適用したモデルのパスを設定し、動作確認済み

**変更点の詳細**

1. chat.py で AutoModelForCausalLM.from_pretrained() でベースモデルをロード
2. その後 PeftModel.from_pretrained() を適用し、LoRA モデルを組み込み
3. config.py で LoRA モデルのパス (LORA_PATH) を管理